### PR TITLE
Minimum Python version is 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     author="Asaf Cohen",
     author_email="asaf@permit.io",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     description="Permit.io python sdk",
     install_requires=get_requirements(),
     classifiers=[


### PR DESCRIPTION
We can drop our minimum Python version slightly. [`aiohttp` requires version 3.7 or above](https://github.com/aio-libs/aiohttp/blob/master/setup.cfg#L42-L43), but there should be nothing wrong with running this code on Python 3.7 rather than 3.8.