### PR TITLE
Add py.typed marker for PEP 561 support (#116)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     install_requires=get_requirements(),
     long_description=get_readme(),
     long_description_content_type="text/markdown",
+    package_data={"permit":["py.typed"]},
     classifiers=[
         "Operating System :: OS Independent",
         "Programming Language :: Python",


### PR DESCRIPTION
**Issue:** #116

**What this PR does:**
- Adds an empty `py.typed` file to the `permit` package.
- Updates `package_data` in `setup.py` to include `py.typed` in the distribution.

**Why:**
This resolves the mypy error `Skipping analyzing 'permit': missing library stubs or py.typed marker` reported in issue #116. Now `mypy` correctly recognizes `permit` as a typed package.

**Testing:**
- Verified locally that `mypy` no longer ignores the `permit` package.
- Installed in editable mode (`pip install -e .`) to confirm the marker is included.